### PR TITLE
fix: remove double quotes from .default.env

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,4 +1,6 @@
 {
   "extends": ["@commitlint/config-conventional"],
-  "rules": {}
+  "rules": {
+    "body-max-line-length": [2, "always", 300]
+  }
 }

--- a/.env.default
+++ b/.env.default
@@ -1,5 +1,5 @@
 ## Do not touch this unless you know what are you doing
-EXCLUDED_NODES="file,file in,watch,exec"
+EXCLUDED_NODES=file,file in,watch,exec
 RETRY_WORKER_CHECKS=true
 ENABLE_HEALTH_API=true
 PALLET_RPC_URL=https://public-rpc.mainnet.energywebx.com
@@ -7,18 +7,18 @@ VOTING_RPC_URL=https://wns-rpc.mainnet.energywebx.com
 PORT=8000
 HOST=localhost
 RED_ENABLE_UI=false
-RED_DIRECTORY="./node-red-data"
-SQLITE_BASE_PATH="./sqlite"
+RED_DIRECTORY=./node-red-data
+SQLITE_BASE_PATH=./sqlite
 SOLUTION_QUEUE_PROCESS_DELAY=20000
 HEARTBEAT_PATH=heartbeat_monitor.txt
 HEARTBEAT_INTERVAL=5000
 HEARTBEAT_PRINT_SUCCESS_LOG=true
-WORKER_REGISTRY_URL="https://workers-registry.energywebx.com"
-PALLET_AUTH_SERVER_DOMAIN="default"
-PALLET_AUTH_SERVER_LOGIN_URL="https://auth.energywebx.com/api/auth/login"
+WORKER_REGISTRY_URL=https://workers-registry.energywebx.com
+PALLET_AUTH_SERVER_DOMAIN=default
+PALLET_AUTH_SERVER_LOGIN_URL=https://auth.energywebx.com/api/auth/login
 
 ## Replace <SEED> with your worker seed
-VOTING_WORKER_SEED="<SEED>"
+VOTING_WORKER_SEED=<SEED>
 
 ## You can set it to true if you want logs to be pretty.
 PRETTY_PRINT=false


### PR DESCRIPTION
Some runtimes i.e. container runtimes might add single quotes to env. variables values causing unexpected issues. This change removes double quotes from .default.env